### PR TITLE
Update kubelet API with SeccompDefault option.

### DIFF
--- a/docs/cluster_spec.md
+++ b/docs/cluster_spec.md
@@ -816,6 +816,20 @@ spec:
 
 Note that Kubelet will fail to install the shutdown inhibtor on systems where logind is configured with an `InhibitDelayMaxSeconds` lower than `shutdownGracePeriod`. On Ubuntu, this setting is 30 seconds.
 
+### SeccompDefault
+
+[SeccompDefault](https://kubernetes.io/blog/2021/08/25/seccomp-default/) enables the use of `RuntimeDefault` as the default seccomp profile for all workloads. (Default: false)
+
+Note that a feature gate is required to enable the feature, and the feature is turned on using kubelet config.
+
+```yaml
+spec:
+  kubelet:
+    featureGates:
+      SeccompDefault: "true"
+    seccompDefault: true
+```
+
 ## kubeScheduler
 
 This block contains configurations for `kube-scheduler`.  See https://kubernetes.io/docs/admin/kube-scheduler/

--- a/k8s/crds/kops.k8s.io_clusters.yaml
+++ b/k8s/crds/kops.k8s.io_clusters.yaml
@@ -3918,6 +3918,10 @@ spec:
                     description: RuntimeRequestTimeout is timeout for runtime requests
                       on - pull, logs, exec and attach
                     type: string
+                  seccompDefault:
+                    description: SeccompDefault enables the use of `RuntimeDefault`
+                      as the default seccomp profile for all workloads.
+                    type: boolean
                   seccompProfileRoot:
                     description: SeccompProfileRoot is the directory path for seccomp
                       profiles.
@@ -4355,6 +4359,10 @@ spec:
                     description: RuntimeRequestTimeout is timeout for runtime requests
                       on - pull, logs, exec and attach
                     type: string
+                  seccompDefault:
+                    description: SeccompDefault enables the use of `RuntimeDefault`
+                      as the default seccomp profile for all workloads.
+                    type: boolean
                   seccompProfileRoot:
                     description: SeccompProfileRoot is the directory path for seccomp
                       profiles.

--- a/k8s/crds/kops.k8s.io_instancegroups.yaml
+++ b/k8s/crds/kops.k8s.io_instancegroups.yaml
@@ -732,6 +732,10 @@ spec:
                     description: RuntimeRequestTimeout is timeout for runtime requests
                       on - pull, logs, exec and attach
                     type: string
+                  seccompDefault:
+                    description: SeccompDefault enables the use of `RuntimeDefault`
+                      as the default seccomp profile for all workloads.
+                    type: boolean
                   seccompProfileRoot:
                     description: SeccompProfileRoot is the directory path for seccomp
                       profiles.

--- a/pkg/apis/kops/componentconfig.go
+++ b/pkg/apis/kops/componentconfig.go
@@ -57,6 +57,8 @@ type KubeletConfigSpec struct {
 	HostnameOverride string `json:"hostnameOverride,omitempty" flag:"hostname-override"`
 	// PodInfraContainerImage is the image whose network/ipc containers in each pod will use.
 	PodInfraContainerImage string `json:"podInfraContainerImage,omitempty" flag:"pod-infra-container-image"`
+	// SeccompDefault enables the use of `RuntimeDefault` as the default seccomp profile for all workloads.
+	SeccompDefault *bool `json:"seccompDefault,omitempty" flag:"seccomp-default"`
 	// SeccompProfileRoot is the directory path for seccomp profiles.
 	SeccompProfileRoot *string `json:"seccompProfileRoot,omitempty" flag:"seccomp-profile-root"`
 	// AllowPrivileged enables containers to request privileged mode (defaults to false)

--- a/pkg/apis/kops/v1alpha2/componentconfig.go
+++ b/pkg/apis/kops/v1alpha2/componentconfig.go
@@ -57,6 +57,8 @@ type KubeletConfigSpec struct {
 	HostnameOverride string `json:"hostnameOverride,omitempty" flag:"hostname-override"`
 	// PodInfraContainerImage is the image whose network/ipc containers in each pod will use.
 	PodInfraContainerImage string `json:"podInfraContainerImage,omitempty" flag:"pod-infra-container-image"`
+	// SeccompDefault enables the use of `RuntimeDefault` as the default seccomp profile for all workloads.
+	SeccompDefault *bool `json:"seccompDefault,omitempty" flag:"seccomp-default"`
 	// SeccompProfileRoot is the directory path for seccomp profiles.
 	SeccompProfileRoot *string `json:"seccompProfileRoot,omitempty" flag:"seccomp-profile-root"`
 	// AllowPrivileged enables containers to request privileged mode (defaults to false)

--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
@@ -5317,6 +5317,7 @@ func autoConvert_v1alpha2_KubeletConfigSpec_To_kops_KubeletConfigSpec(in *Kubele
 	out.PodManifestPath = in.PodManifestPath
 	out.HostnameOverride = in.HostnameOverride
 	out.PodInfraContainerImage = in.PodInfraContainerImage
+	out.SeccompDefault = in.SeccompDefault
 	out.SeccompProfileRoot = in.SeccompProfileRoot
 	out.AllowPrivileged = in.AllowPrivileged
 	out.EnableDebuggingHandlers = in.EnableDebuggingHandlers
@@ -5418,6 +5419,7 @@ func autoConvert_kops_KubeletConfigSpec_To_v1alpha2_KubeletConfigSpec(in *kops.K
 	out.PodManifestPath = in.PodManifestPath
 	out.HostnameOverride = in.HostnameOverride
 	out.PodInfraContainerImage = in.PodInfraContainerImage
+	out.SeccompDefault = in.SeccompDefault
 	out.SeccompProfileRoot = in.SeccompProfileRoot
 	out.AllowPrivileged = in.AllowPrivileged
 	out.EnableDebuggingHandlers = in.EnableDebuggingHandlers

--- a/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
@@ -3676,6 +3676,11 @@ func (in *KubeletConfigSpec) DeepCopyInto(out *KubeletConfigSpec) {
 		*out = new(int32)
 		**out = **in
 	}
+	if in.SeccompDefault != nil {
+		in, out := &in.SeccompDefault, &out.SeccompDefault
+		*out = new(bool)
+		**out = **in
+	}
 	if in.SeccompProfileRoot != nil {
 		in, out := &in.SeccompProfileRoot, &out.SeccompProfileRoot
 		*out = new(string)

--- a/pkg/apis/kops/v1alpha3/componentconfig.go
+++ b/pkg/apis/kops/v1alpha3/componentconfig.go
@@ -57,6 +57,8 @@ type KubeletConfigSpec struct {
 	HostnameOverride string `json:"-"`
 	// PodInfraContainerImage is the image whose network/ipc containers in each pod will use.
 	PodInfraContainerImage string `json:"podInfraContainerImage,omitempty" flag:"pod-infra-container-image"`
+	// SeccompDefault enables the use of `RuntimeDefault` as the default seccomp profile for all workloads.
+	SeccompDefault *bool `json:"seccompDefault,omitempty" flag:"seccomp-default"`
 	// SeccompProfileRoot is the directory path for seccomp profiles.
 	SeccompProfileRoot *string `json:"seccompProfileRoot,omitempty" flag:"seccomp-profile-root"`
 	// AllowPrivileged was removed.

--- a/pkg/apis/kops/v1alpha3/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha3/zz_generated.conversion.go
@@ -5674,6 +5674,7 @@ func autoConvert_v1alpha3_KubeletConfigSpec_To_kops_KubeletConfigSpec(in *Kubele
 	out.PodManifestPath = in.PodManifestPath
 	out.HostnameOverride = in.HostnameOverride
 	out.PodInfraContainerImage = in.PodInfraContainerImage
+	out.SeccompDefault = in.SeccompDefault
 	out.SeccompProfileRoot = in.SeccompProfileRoot
 	out.AllowPrivileged = in.AllowPrivileged
 	out.EnableDebuggingHandlers = in.EnableDebuggingHandlers
@@ -5775,6 +5776,7 @@ func autoConvert_kops_KubeletConfigSpec_To_v1alpha3_KubeletConfigSpec(in *kops.K
 	out.PodManifestPath = in.PodManifestPath
 	out.HostnameOverride = in.HostnameOverride
 	out.PodInfraContainerImage = in.PodInfraContainerImage
+	out.SeccompDefault = in.SeccompDefault
 	out.SeccompProfileRoot = in.SeccompProfileRoot
 	out.AllowPrivileged = in.AllowPrivileged
 	out.EnableDebuggingHandlers = in.EnableDebuggingHandlers

--- a/pkg/apis/kops/v1alpha3/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/v1alpha3/zz_generated.deepcopy.go
@@ -3629,6 +3629,11 @@ func (in *KubeletConfigSpec) DeepCopyInto(out *KubeletConfigSpec) {
 		*out = new(int32)
 		**out = **in
 	}
+	if in.SeccompDefault != nil {
+		in, out := &in.SeccompDefault, &out.SeccompDefault
+		*out = new(bool)
+		**out = **in
+	}
 	if in.SeccompProfileRoot != nil {
 		in, out := &in.SeccompProfileRoot, &out.SeccompProfileRoot
 		*out = new(string)

--- a/pkg/apis/kops/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/zz_generated.deepcopy.go
@@ -3808,6 +3808,11 @@ func (in *KubeletConfigSpec) DeepCopyInto(out *KubeletConfigSpec) {
 		*out = new(int32)
 		**out = **in
 	}
+	if in.SeccompDefault != nil {
+		in, out := &in.SeccompDefault, &out.SeccompDefault
+		*out = new(bool)
+		**out = **in
+	}
 	if in.SeccompProfileRoot != nil {
 		in, out := &in.SeccompProfileRoot, &out.SeccompProfileRoot
 		*out = new(string)


### PR DESCRIPTION
This is essentially a copy of https://github.com/kubernetes/kops/pull/15925 so we can use it before it is merged upstream